### PR TITLE
Catch ValueError when verifying RSA signature.

### DIFF
--- a/src/jwkest/jws.py
+++ b/src/jwkest/jws.py
@@ -133,10 +133,13 @@ class RSASigner(Signer):
     def verify(self, msg, sig, key):
         h = self.digest.new(msg)
         verifier = PKCS1_v1_5.new(key)
-        if verifier.verify(h, sig):
-            return True
-        else:
-            raise BadSignature()
+        try:
+            if verifier.verify(h, sig):
+                return True
+            else:
+                raise BadSignature()
+        except ValueError as e:
+            raise BadSignature(str(e))
 
 
 class DSASigner(Signer):


### PR DESCRIPTION
Not documented at https://www.dlitz.net/software/pycrypto/api/2.6/Crypto.Signature.PKCS1_v1_5.PKCS115_SigScheme-class.html, but ValueError may be thrown if the signature is majorly broken. 