### PR TITLE
Ability to pass in protected headers to sign_compact.

### DIFF
--- a/src/jwkest/jwk.py
+++ b/src/jwkest/jwk.py
@@ -267,7 +267,7 @@ class Key(object):
                 continue
 
             if isinstance(item, bytes):
-                item = str(item)
+                item = item.decode('utf-8')
                 setattr(self, param, item)
 
             try:

--- a/src/jwkest/jws.py
+++ b/src/jwkest/jws.py
@@ -430,11 +430,12 @@ class JWS(JWx):
 
         return key, xargs
 
-    def sign_compact(self, keys=None):
+    def sign_compact(self, keys=None, protected=None):
         """
         Produce a JWS using the JWS Compact Serialization
 
         :param keys: A dictionary of keys
+        :param protected: The protected headers (a dictionary)
         :return:
         """
 
@@ -451,7 +452,8 @@ class JWS(JWx):
         else:
             keys = self._pick_keys(self._get_keys(), use="sig", alg=_alg)
 
-        xargs = {"alg": _alg}
+        xargs = protected or {}
+        xargs["alg"] = _alg
 
         if keys:
             key = keys[0]
@@ -477,10 +479,10 @@ class JWS(JWx):
         except KeyError:
             raise UnknownAlgorithm(_alg)
 
-        _input = b".".join([b64encode_item(xargs), b64encode_item(self.msg)])
+        _input = jwt.pack(parts=[self.msg])
         sig = _signer.sign(_input, key.get_key(alg=_alg, private=True))
         logger.debug("Signed message using key with kid=%s" % key.kid)
-        return jwt.pack(parts=[self.msg, sig])
+        return b".".join([_input, b64encode_item(sig)])
 
     def verify_compact(self, jws, keys=None, allow_none=False, sigalg=None):
         """
@@ -589,7 +591,9 @@ class JWS(JWx):
 
         _claim = None
         for _sign in _signs:
-            token = b".".join([_sign["header"], _payload, _sign["signature"]])
+            token = b".".join([_sign["protected"].encode(), _payload.encode(), _sign["signature"].encode()])
+            header = _sign.get("header", {})
+            self.__init__(**header)
             _tmp = self.verify_compact(token, keys, allow_none, sigalg)
             if _claim is None:
                 _claim = _tmp

--- a/src/jwkest/jwt.py
+++ b/src/jwkest/jwt.py
@@ -39,9 +39,11 @@ def b64encode_item(item):
 
 class JWT(object):
     def __init__(self, **headers):
+        if not headers.get("alg"):
+            headers["alg"] = None
         self.headers = headers
-        self.part = []
-        self.b64part = []
+        self.b64part = [ b64encode_item(headers) ]
+        self.part = [ b64d(self.b64part[0]) ]
 
     def unpack(self, token):
         """
@@ -71,7 +73,8 @@ class JWT(object):
             else:
                 headers = {'alg': 'none'}
 
-        _all = [b64encode_item(headers)]
+        self.part = [ self.part[0] ] + parts
+        _all = self.b64part = [ self.b64part[0] ]
         _all.extend([b64encode_item(p) for p in parts])
 
         return b".".join(_all)

--- a/tests/test_3_jws.py
+++ b/tests/test_3_jws.py
@@ -5,7 +5,7 @@ from jwkest.ecc import P521
 
 import jwkest
 from jwkest import jws
-from jwkest import b64e
+from jwkest import b64d, b64e
 
 from jwkest.jwk import SYMKey, KEYS
 from jwkest.jwk import ECKey
@@ -15,6 +15,9 @@ from jwkest.jws import SIGNER_ALGS, factory
 from jwkest.jws import JWSig
 from jwkest.jws import JWS
 
+import codecs
+import json
+import io
 import os.path
 
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
@@ -354,6 +357,51 @@ def test_sign_2():
     jws = JWS("payload", alg="RS512")
     jws.sign_compact(keys=keys)
 
+def test_signer_protected_headers():
+    payload = "Please take a moment to register today"
+    _key = ECKey().load_key(P256)
+    keys = [_key]
+    _jws = JWS(payload, alg="ES256")
+    protected = dict(header1=u"header1 is protected",
+        header2="header2 is protected too", a=1)
+    _jwt = _jws.sign_compact(keys, protected=protected)
+
+    exp_protected = protected.copy()
+    exp_protected['alg'] = 'ES256'
+    enc_header, enc_payload, sig = _jwt.split(b'.')
+    assert json.loads(b64d(enc_header).decode("utf-8")) == exp_protected
+    assert b64d(enc_payload).decode("utf-8") == payload
+
+    _rj = JWS()
+    info = _rj.verify_compact(_jwt, keys)
+    assert info == payload
+
+def test_verify_protected_headers():
+    payload = "Please take a moment to register today"
+    _key = ECKey().load_key(P256)
+    keys = [_key]
+    _jws = JWS(payload, alg="ES256")
+    protected = dict(header1=u"header1 is protected",
+        header2="header2 is protected too", a=1)
+    _jwt = _jws.sign_compact(keys, protected=protected)
+    protectedHeader, enc_payload, sig = _jwt.split(b".")
+    data = dict(payload=enc_payload, signatures=[
+        dict(
+            header=dict(alg=u"ES256", jwk=_key.serialize()),
+            protected=protectedHeader,
+            signature=sig,
+            )
+        ])
+    fobj = io.BytesIO(JSONEncoder().encode(data).encode("utf-8"))
+    _jws = JWS()
+    reader = codecs.getreader("utf-8")
+    assert _jws.verify_json(reader(fobj)) == payload
+
+class JSONEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, bytes):
+            return o.decode('utf-8')
+        return json.JSONEncoder.default(self, o)
 
 if __name__ == "__main__":
     test_sign_2()


### PR DESCRIPTION
Signatures may not validate if multiple (protected) headers are fed in. This
is related to sign_compact computing the b64 representation of the protected
headers (xargs) outside of the jwt, and then using jwt.pack() which would
re-serialize the protected headeres, potentially changing the way the json is
formatted.