### PR TITLE
Fix: encode utf8 before using urlsafe_b64decode

### DIFF
--- a/src/jwkest/__init__.py
+++ b/src/jwkest/__init__.py
@@ -175,7 +175,7 @@ def b64d(b):
     if cb == b:
         b = add_padding(b)
 
-    return base64.urlsafe_b64decode(b)
+    return base64.urlsafe_b64decode(b.encode('utf-8'))
 
 
 # 'Stolen' from Werkzeug


### PR DESCRIPTION
This patch is for https://github.com/rohe/pyjwkest/issues/30

Greetings.