### PR TITLE
Use the base64 encoded data when repacking an unpacked JWT.

### DIFF
--- a/src/jwkest/jwt.py
+++ b/src/jwkest/jwt.py
@@ -79,7 +79,7 @@ class JWT(object):
                 headers = {'alg': 'none'}
 
         if not parts:
-            parts = self.part[1:]
+            return ".".join([a.decode() for a in self.b64part])
 
         self.part = [headers] + parts
         _all = self.b64part = [b64encode_item(headers)]


### PR DESCRIPTION
To ensure the signature is correct, the parts can not be re-encoded since
attribute order is not guaranteed.