### PR TITLE
Use the exact header value from the JWE.

### DIFF
--- a/src/jwkest/jwe.py
+++ b/src/jwkest/jwe.py
@@ -695,7 +695,7 @@ class JWE_EC(JWe):
 
         msg, valid = super(JWE_EC, self)._decrypt(self.headers["enc"], self.cek,
                                                   self.ctxt,
-                                                  token.b64_encode_header(),
+                                                  token.b64part[0],
                                                   self.iv, self.tag)
         self.msg = msg
         self.msg_valid = valid


### PR DESCRIPTION
Fixes the spurious Travis errors (which occurs because tox uses random PYTHONHASHSEED, which affects Python dict key order) like: https://travis-ci.org/rohe/pyjwkest/jobs/107722738.